### PR TITLE
Fixes to IA and new runtime policy calls

### DIFF
--- a/aqua/aqua.py
+++ b/aqua/aqua.py
@@ -614,25 +614,65 @@ class Aqua():
         response = requests.get(url, verify=self.verify_tls, headers=self.headers, proxies=self.proxy)
         return json.loads(response.content.decode('utf-8'))   
 
-    def get_image_assurance(self, policy_name: str):
+    def get_image_assurance(self, policy_name: str, policy_type: str):
         """
         Return the structure of an image runtime profile
 
         :param profile_name: name of profile to retrieve
+        :param policy_type: the type of assurance policy (image | host | function | cf_application)
         :return: the structure of an image runtime profile
-        """
-        url = "{}/assurance_policy/{}".format(self.url_prefix.replace('v1', 'v2'), policy_name)
-        return self.send_request(url)
 
-    def modify_image_assurance(self, policy_name: str, policy_file: str):
+        NOTE: 
+        """
+        url = "{}/assurance_policy/{}/{}".format(self.url_prefix.replace('v1', 'v2'),policy_type, policy_name)
+        response = requests.get(url, verify=self.verify_tls, headers=self.headers, proxies=self.proxy)
+        return json.loads(response.content.decode('utf-8'))   
+
+    def modify_image_assurance(self, policy_name: str, policy_file: str, policy_type: str):
         """
         Update an existing image assurance policy
 
         :param policy_name: name of policy to update
         :param policy_file: json object i.e. returned from list_image_assurance or get_image_assurance
+        :param policy_type: the type of assurance policy (image | host | function | cf_application)
         :return: A successful creation of the new profile will result in a 204 No Content response.
         """
-        url = "{}/assurance_policy/{}".format(self.url_prefix, policy_name)
+        url = "{}/assurance_policy/{}/{}".format(self.url_prefix.replace('v1', 'v2'),policy_type, policy_name)
+        response = requests.put(url, data=str(policy_file), verify=self.verify_tls, headers=self.headers, proxies=self.proxy)
+        return response
+
+######################################################################
+#  the retrieval and modification of runtime policies
+######################################################################
+    def list_runtime_policies(self):
+        """
+        Lists of all runtime policies in the system
+
+        :return: a list of all runtime policies in a json
+        """
+        url = "{}/runtime_policies".format(self.url_prefix.replace('v1', 'v2'))
+        response = requests.get(url, verify=self.verify_tls, headers=self.headers, proxies=self.proxy)
+        return json.loads(response.content.decode('utf-8'))   
+
+    def get_runtime_policies(self, policy_name: str):
+        """
+        Return the structure of a runtime policy
+
+        :param profile_name: name of policy to retrieve
+        :return: the structure of a runtime policy
+        """
+        url = "{}/runtime_policies/{}".format(self.url_prefix.replace('v1', 'v2'), policy_name)
+        return self.send_request(url)
+
+    def modify_runtime_policies(self, policy_name: str, policy_file: str):
+        """
+        Update an existing image assurance policy
+
+        :param policy_name: name of policy to update
+        :param policy_file: json object i.e. returned from list_runtime_policies or get_runtime_policies
+        :return: A successful creation of the new policy will result in a 204 No Content response.
+        """
+        url = "{}/runtime_policies/{}".format(self.url_prefix.replace('v1', 'v2'), policy_name)
         response = requests.put(url, data=policy_file, verify=self.verify_tls, headers=self.headers, proxies=self.proxy)
         return response
 

--- a/examples/get_rp.py
+++ b/examples/get_rp.py
@@ -8,18 +8,18 @@ aqua = Aqua(id='apiuser', password='apiuserpassword', host='aqua.yourdomain.com'
 
 # Expected parameters are registry, hosts, containers_app
 # Sending zero filters to retrieve entire CSP landscape
-ia_policies = aqua.list_image_assurance()
+rp_policies = aqua.list_runtime_policies()
 # Print the total running containers and containers running with at least one critical vulnerability
-print("Total IA policies: " + str(ia_policies['count']))
+print("Total Runtime policies: " + str(rp_policies['count']))
 
-print(ia_policies)
-if not os.path.exists("ia"):
-    os.makedirs("ia")
+print(rp_policies)
+if not os.path.exists("rp"):
+    os.makedirs("rp")
 
-for p in ia_policies["result"]:
-    if not os.path.exists("ia/" + p["assurance_type"]):
-        os.makedirs("ia/" + p["assurance_type"])
-    with open("ia/" + p["assurance_type"] + "/" + p["name"], 'w') as f:
+for p in rp_policies["result"]:
+    if not os.path.exists("rp/" + p["runtime_type"]):
+        os.makedirs("rp/" + p["runtime_type"])
+    with open("rp/" + p["runtime_type"] + "/" + p["name"], 'w') as f:
         json.dump(p,f)
 
 

--- a/examples/mod_ia.py
+++ b/examples/mod_ia.py
@@ -1,0 +1,32 @@
+from aqua import Aqua
+import json, os
+# Use Cases
+# Get a named policy by name, modify it and put it back
+
+# Get JWT token from Aqua CSP
+aqua = Aqua(id='apiuser', password='apiuserpassword', host='aqua.yourdomain.com', port='443', using_tls=True)
+
+# Get the policy named Aqua-Demo.  I could use list policies to get all the names but I already know the name of this one
+
+ia_policy = aqua.get_image_assurance("Aqua-Demo","image")
+
+# Print the total running containers and containers running with at least one critical vulnerability
+print("Policy received: " + str(ia_policy))
+
+# Change scan_sensitive_data: true
+ia_policy["scan_sensitive_data"]=True
+
+print("Policy modified: " + str(ia_policy))
+
+with open("tmp_policy", 'w') as f:
+    json.dump(ia_policy,f)
+
+policy_type=ia_policy["assurance_type"]
+resp = aqua.modify_image_assurance("Aqua-Demo", json.dumps(ia_policy), policy_type)
+
+print (str(resp))
+
+
+
+
+

--- a/examples/mod_rp.py
+++ b/examples/mod_rp.py
@@ -1,0 +1,34 @@
+from aqua import Aqua
+import json, os
+# Use Cases
+# Get a named policy by name, modify it and put it back
+
+# Get JWT token from Aqua CSP
+aqua = Aqua(id='apiuser', password='apiuserpassword', host='aqua.yourdomain.com', port='443', using_tls=True)
+
+# Get the policy named CIS.  I could use list policies to get all the names but I already know the name of this one
+
+rp_policy = aqua.get_runtime_policies("CIS")
+
+# Print the total running containers and containers running with at least one critical vulnerability
+print("Policy received: " + str(rp_policy))
+
+# Change enable_fork_guard: true
+rp_policy["enable_fork_guard"]=True
+rp_policy["fork_guard_process_limit"]=100
+
+
+print("Policy modified: " + str(rp_policy))
+
+# Save for post debug and viewing (optional)
+with open("tmp_policy", 'w') as f:
+    json.dump(rp_policy,f)
+
+resp = aqua.modify_runtime_policies("CIS", json.dumps(rp_policy))
+
+print (str(resp))
+
+
+
+
+


### PR DESCRIPTION
Docs for IA were incorrect.  Had to fix the get and modify for IA and add a policy type field.
Added a test example getting an IA policy, make a small change and putting it back.  

Added SDK calls for runtime policies to get all or get one by name.

Added an example to getting a runtime policy, make a small change and put it back.  